### PR TITLE
Remove name.vessel.airplane from se vocab

### DIFF
--- a/www/vocab/1.0
+++ b/www/vocab/1.0
@@ -23,7 +23,6 @@ se
 			auto
 			train
 		vessel
-			airplane
 			boat
 			ship
 		publication


### PR DESCRIPTION
Duplicate with name.vehicle.airplane, and only the vehicle is allowed via `se lint`

Follow-up from [mailing list](https://groups.google.com/g/standardebooks/c/ICyaNlaPj5A/m/kKa7J5_hAgAJ)